### PR TITLE
prevent stuck left-scroll due to negative value

### DIFF
--- a/assets/hb/modules/slide/js/index.ts
+++ b/assets/hb/modules/slide/js/index.ts
@@ -13,20 +13,16 @@
     const step = inner.offsetWidth
     let left = 0
     if (dir === 'left') {
-      left = inner.scrollLeft - step
+      left = Math.max(inner.scrollLeft - step, 0 - inner.scrollLeft)
     } else {
       left = Math.min(inner.scrollWidth - inner.clientWidth, inner.scrollLeft + step)
-    }
-    if (left <= 0) {
-      scrolling = false
-      return
     }
 
     inner.scroll({
       left
     })
     const checker = setInterval(() => {
-      if (left === inner.scrollLeft) {
+      if (left === inner.scrollLeft || inner.scrollLeft === 0) {
         scrolling = false
         clearInterval(checker)
       }


### PR DESCRIPTION
Currently `scroll(event, "left")` only works when the calculated scroll value (`left`) is higher than zero. When the scroll area is small (e.g. only 4 items) then the calculated scroll value is always below zero. Still this value can be used for `inner.scroll()` as a negative value also indicates scrolling into left direction.
This issue can be seen on https://hbstack.dev/modules/components/slide/ when scrolling to right direction only once and then trying to scroll left. It fails as it always ends up in
https://github.com/Andrwe/hbstack-slide/blob/main/assets/hb/modules/slide/js/index.ts#L20

This patch changes the calculation of scroll value by using the maximum out of either `inner.scrollLeft - step` or `0 - inner.scrollLeft`. This results in left scrolling by either a value that is smaller than the left scrolling area or scrolling to 0 and therefore showing the left-most item.
Because of this change the check for out-of-bound scrolling based on L20 can be removed as the calculated value is always within the bounds of the scrolling area.